### PR TITLE
add bioconductor ReatomeGSA as tool dependency

### DIFF
--- a/galaxy/local_tools/reactome/reactome.xml
+++ b/galaxy/local_tools/reactome/reactome.xml
@@ -1,6 +1,10 @@
 <tool id="reactome" name="Reactome Analysis" version="0.1.0">
     <description>Perform a Reactome analysis</description>
 
+    <requirements>
+        <requirement type="package" version="1.20.0">bioconductor-reactomegsa</requirement>
+    </requirements>
+
     <command><![CDATA[
 #set $subcommand_arg = ''
 #set $project_to_human_arg = ''


### PR DESCRIPTION
Fixes #43, alternative to PR #44. 

This just adds the bioconductor ReactomeGSA conda package as a tool dependency. Our own cli can probably be added as an additional conda dependency when packaged and uploaded.

Configuring reactome conda package handling is done in the galaxy install's galaxy.yml, and the conda-forge and bioconda channels need to be enabled there by the galaxy admin.