### PR TITLE
ReactomeGSA output files

### DIFF
--- a/galaxy/local_tools/reactome-gsa/reactome-gsa.xml
+++ b/galaxy/local_tools/reactome-gsa/reactome-gsa.xml
@@ -23,6 +23,10 @@ Rscript ${__tool_directory__}/reactome_analysis.R
   --use_interactors='$use_interactors'
   --include_disease_pathways='$include_disease_pathways'
   --pathways_output_file='$pathways'
+  --entities_found_output_file='$entities_found'
+  --entities_not_found_output_file='$entities_not_found'
+  --pdf_output_file='$pdf_output'
+  --json_output_file='$json_output'
   --comparison_factor='$comparison_factor'
   --reference_group='$reference_group'
   --comparison_group='$comparison_group'
@@ -180,6 +184,10 @@ Rscript ${__tool_directory__}/reactome_analysis.R
 
     <outputs>
         <data format="csv" name="pathways" label="Pathways"/>
+        <data format="csv" name="entities_found" label="Entities found"/>
+        <data format="csv" name="entities_not_found" label="Entities not found"/>
+        <data format="pdf" name="pdf_output" label="PDF Output"/>
+        <data format="json" name="json_output" label="JSON Output"/>
     </outputs>
 
     <help><![CDATA[

--- a/galaxy/local_tools/reactome-gsa/reactome-gsa.xml
+++ b/galaxy/local_tools/reactome-gsa/reactome-gsa.xml
@@ -5,6 +5,7 @@
         <requirement type="package" version="1.20.0">bioconductor-reactomegsa</requirement>
         <requirement type="package" version="1.20.0">bioconductor-reactomegsa.data</requirement>
         <requirement type="package" version="1">r-optparse</requirement>
+        <requirement type="package" version="1">r-httr</requirement>
     </requirements>
 
     <stdio>

--- a/galaxy/local_tools/reactome-gsa/reactome_analysis.R
+++ b/galaxy/local_tools/reactome-gsa/reactome_analysis.R
@@ -127,6 +127,7 @@ cat("Successfully loaded annotation from:", opt$annotation, "\n")
 request <- ReactomeAnalysisRequest(method = opt$method)
 
 request <- set_parameters(request = request,
+                          create_reports = TRUE,
                           max_missing_values = opt$max_missing_values,
                           use_interactors = opt$use_interactors,
                           include_disease_pathways = opt$include_disease_pathways)
@@ -187,6 +188,8 @@ str(request)
 cat("Performing Reactome GSA analysis...\n")
 result <- perform_reactome_analysis(request = request, compress = FALSE)
 cat("Analysis complete.\n")
+
+links = reactome_links(result)
 
 pathways <- get_result(result, type = "pathways", name = opt$name)
 write.csv(pathways, file = opt$pathways_output_file, row.names = FALSE)

--- a/src/main/kotlin/org/reactome/cli/ReactomeCli.kt
+++ b/src/main/kotlin/org/reactome/cli/ReactomeCli.kt
@@ -6,7 +6,6 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.Json
 import java.io.File
 
 private const val CLI_USER_AGENT = "Mozilla/5.0 (compatible; Reactome CLI/1.0)"
@@ -132,7 +131,7 @@ class ReactomeCli(
     }
 
     private fun downloadResultJson(token: String, filename: String) {
-        val url = "$reactomeUrl/AnalysisService/download/${token}/result.json"
+        val url = "${analysisUrl()}/download/${token}/result.json"
         val content = getTextContent(url)
         File(filename).writeText(content)
     }


### PR DESCRIPTION
Adds some standard output files:

* pathways csv, now from reactome.org instead of extracted from the R client's output
* entities found csv
* entities not found csv
* json output
* pdf output from reactome

Note however there are 2 other reports constructed, a second pdf output from gsa.reactome.org and an excel output from the latter as well. I haven't found an interface to extract the token required to retrieve these, its different from the token from www.reactome.org for the above pathways csv & friends. But this should move us forward.

