### PR TITLE
#53: Add dynamic options for comparison type and covariates

### DIFF
--- a/galaxy/local_tools/reactome-gsa/reactome-gsa.xml
+++ b/galaxy/local_tools/reactome-gsa/reactome-gsa.xml
@@ -175,8 +175,7 @@ Rscript ${__tool_directory__}/reactome_analysis.R
         <param name="reference_group" type="text" label="Reference group"
                help="The baseline group against which other groups are compared. It usually represents the
                standard or default condition."
-               optional="false"
-               refresh_on_change="true"/>
+               optional="false"/>
 
         <param name="comparison_group" type="text" label="Comparison group"
                help="The group being compared to the reference group to assess differences or effects."


### PR DESCRIPTION
These can be derived from metadata header.

The others, comparison and reference group, require data from the rows and therefore custom python 
extension. I've played with this and was unable to get it working, and found it deprecated. I've decided
not to pursue at this point. 

